### PR TITLE
Fix TODO in extractConfigProperties()

### DIFF
--- a/bin/wsadminlib.py
+++ b/bin/wsadminlib.py
@@ -1115,8 +1115,7 @@ def restartServer( nodename, servername, maxwaitseconds, ):
 def extractConfigProperties( nodename, servername, propsfilename, ):
     """Converts the server configuration from xml files to a flat properties file"""
     m = "extractConfigProperties:"
-    # TODO: Figure out how to specify the node name...
-    arglist = ['-propertiesFileName',propsfilename,'-configData','Server=%s' % ( servername )]
+    arglist = ['-propertiesFileName',propsfilename,'-configData','Node=%s:Server=%s' % ( nodename, servername )]
     sop(m,"Calling AdminTask.extractConfigProperties() with arglist=%s" % ( arglist ))
     return AdminTask.extractConfigProperties( arglist )
 


### PR DESCRIPTION
Tested this locally on WAS V8 to make sure it works; there is no real way to test this in a unit test as WAS only creates the properties file silently and the content of the file can't be checked easily from a unit test.