### PR TITLE
Fix handling of lists without '[]', which fixes #16 and

### DIFF
--- a/bin/wsadminlib.py
+++ b/bin/wsadminlib.py
@@ -5433,11 +5433,10 @@ def getObjectCustomProperty(object_id, propname):
     #print "value of properties attribute=%s" % x
     # This can be of the format "[foo(value) bar(baz)]" where the values are "foo(value)",
     # "bar(baz)".  It also seems to be able to be just "foo(value)"
-    # FIXME: should we use _splitlist here?  If so, we need to change it to work when no [] are given
     if x.startswith("["):
-        propsidlist = x[1:-1].split(' ')
+        propsidlist = _splitlist(x)
     else:
-        propsidlist = [x]
+        propsidlist = _splitlist('[' + x + ']')
     #print "List of properties = %s" % repr(propsidlist)
     for id in propsidlist:
         #print "id=%s" % id


### PR DESCRIPTION
fix TODO in getObjectCustomProperty()

Unfortunately I'm not able to reproduce the issue on my server; on my test environment WAS denies any modify on the 'properties' item when that item is not a collection of 'Property' objects with enclosing brackets.

If there are any ideas on how to come up with a reliable automated test for this, please let me know. The code has been tested by a user manually on his environment as part of issue #16.