### PR TITLE
add getAdminAppViewValueList

### DIFF
--- a/bin/wsadminlib.py
+++ b/bin/wsadminlib.py
@@ -3849,7 +3849,7 @@ def getDeploymentAutoStart(deploymentname,deploymenttargetname):
     return rc
 
 
-def getAdminAppViewValueList(appname, keyname):
+def getAdminAppViewList(appname, keyname):
     """ Returns a list of dictionaries reflecting the human readable output
         product by AdminApp.view. Each list element is a module returned by
         AdminApp.view, and the dictionary is the "meat" of the command output.
@@ -3861,7 +3861,7 @@ def getAdminAppViewValueList(appname, keyname):
     """
 
     getAdminAppViewValueList_REGEX = re.compile('^(\w+): (.+)')
-    m = "getAdminAppViewValueList"
+    m = "getAdminAppViewList"
     allmodules = []
     mymod = {}
     sawfirstmodule = False


### PR DESCRIPTION
getAdminAppViewValueList is an alternative to getAdminAppViewValue getAdminAppViewValueList handles multipme modules and returns all keys/values foudn in the human readable AdminApp.edit output


```
for app in listApplications():
  print  getAdminAppViewValueList(app, "-MapModulesToServers")
[{u'Server': u'WebSphere:cell=ndcell,node=node1,server=server1+WebSphere:cell=ndcell,node=node1,server=webserver1+WebSphere:cell=ndcell,node=test-node,server=webserver2', u'URI': u'Silly.war,WEB-INF/web.xml', u'Module': u'Silly'}]
[{u'Server': u'WebSphere:cell=ndcell,node=node1,server=server1+WebSphere:cell=ndcell,node=node1,server=webserver1', u'URI': u'guide-maven-multimodules-war-1.0-SNAPSHOT.war,WEB-INF/web.xml', u'Module': u'Archetype Created Web Application'}, {u'Server': u'WebSphere:cell=ndcell,node=node1,server=server1+WebSphere:cell=ndcell,node=node1,server=webserver1', u'URI': u'guide-maven-multimodules-war-1.0-SNAPSHOT.war2,WEB-INF/web.xml', u'Module': u'Archetype Created Web Application'}]
```
