### PR TITLE
cleanup test server

### DIFF
--- a/tests/wsadminlib.test.py
+++ b/tests/wsadminlib.test.py
@@ -121,6 +121,11 @@ def testAndGetNamesND(cfg):
     
     # Create an server.
     serverName = 'wsadminlibsrv'
+
+    # in case of exception
+    if getServerByNodeAndName(nodeName,serverName) is not None:
+        deleteServerByNodeAndName(nodeName, serverName)
+
     serverID = createServer(nodeName, serverName)
     if serverID is None:
         errbrk(m,"Failed to create a server.")
@@ -340,20 +345,6 @@ def testVirtualHost(cfg):
     # Load Microsoft MIME Types not included with WAS V6.0 by default
     setVirtualHostMimeTypeForExtension(testVirtualHost, 'docm', 'application/vnd.ms-word.document.macroEnabled.12')
     setVirtualHostMimeTypeForExtension(testVirtualHost, 'docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document')
-    setVirtualHostMimeTypeForExtension(testVirtualHost, 'dotm', 'application/vnd.ms-word.template.macroEnabled.12')
-    setVirtualHostMimeTypeForExtension(testVirtualHost, 'dotx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.template')
-    setVirtualHostMimeTypeForExtension(testVirtualHost, 'ppam', 'application/vnd.ms-powerpoint.addin.macroEnabled.12')
-    setVirtualHostMimeTypeForExtension(testVirtualHost, 'ppsm', 'application/vnd.ms-powerpoint.slideshow.macroEnabled.12')
-    setVirtualHostMimeTypeForExtension(testVirtualHost, 'ppsx', 'application/vnd.openxmlformats-officedocument.presentationml.slideshow')
-    setVirtualHostMimeTypeForExtension(testVirtualHost, 'pptm', 'application/vnd.ms-powerpoint.presentation.macroEnabled.12')
-    setVirtualHostMimeTypeForExtension(testVirtualHost, 'pptx', 'application/vnd.openxmlformats-officedocument.presentationml.presentation')
-    setVirtualHostMimeTypeForExtension(testVirtualHost, 'sldx', 'application/vnd.openxmlformats-officedocument.presentationml.slide')
-    setVirtualHostMimeTypeForExtension(testVirtualHost, 'xlsb', 'application/vnd.ms-excel.sheet.binary.macroEnabled.12')
-    setVirtualHostMimeTypeForExtension(testVirtualHost, 'xlsm', 'application/vnd.ms-excel.sheet.macroEnabled.12')
-    setVirtualHostMimeTypeForExtension(testVirtualHost, 'xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
-    setVirtualHostMimeTypeForExtension(testVirtualHost, 'xltm', 'application/vnd.ms-excel.template.macroEnabled.12')
-    setVirtualHostMimeTypeForExtension(testVirtualHost, 'xps', 'application/vnd.ms-xpsdocument')
-
     deleteVirtualHost(testVirtualHost)
 
     sop(m,"Exit. Success.")
@@ -505,6 +496,7 @@ def testBase():
     testClassloaders(cfg)
     testClusters(cfg)
     testGetObjectByNodeServerAndName(cfg)
+    deleteServerByNodeAndName(cfg["nodeName"], cfg["serverName"])
     sop(m,"Exit success. cfg=" + repr(cfg))
 
 def testND():
@@ -527,6 +519,8 @@ def testND():
     testClusters(cfg)
     testProxyServer(cfg)
     testGetObjectByNodeServerAndName(cfg)
+    deleteServerByNodeAndName(cfg["nodeName"], cfg["serverName"])
+
     sop(m,"Exit. Success.")
 
 


### PR DESCRIPTION
Fixes #49

also removes all but two mimetype additions. These are surprisingly slow and don't add anything in this context.